### PR TITLE
Changing the removed method 'share' to 'singleton'

### DIFF
--- a/src/GGDX/LaravelInsightly/InsightlyServiceProvider.php
+++ b/src/GGDX/LaravelInsightly/InsightlyServiceProvider.php
@@ -26,9 +26,8 @@ class InsightlyServiceProvider extends ServiceProvider
     public function register()
     {
 
-        $this->app['ggdx.insightly'] = $this->app->share(function($app){
+        $this->app->singleton('ggdx.insightly',function($app){
             $config = $app->config->get('insightly', []);
-
             return new Insightly($config['api_key'], $config['api_version']);
         });
 


### PR DESCRIPTION
As of Laravel 5.4 share method has been removed: https://laravel.com/docs/5.4/upgrade

Recommended replacement is singleton method.