### PR TITLE
Changing the removed method 'share' to 'singleton'

### DIFF
--- a/src/GGDX/LaravelInsightly/InsightlyServiceProvider.php
+++ b/src/GGDX/LaravelInsightly/InsightlyServiceProvider.php
@@ -26,14 +26,11 @@ class InsightlyServiceProvider extends ServiceProvider
     public function register()
     {
 
-        $this->app['ggdx.insightly'] = $this->app->share(function($app){
+        $this->app->singleton('ggdx.insightly',function($app){
             $config = $app->config->get('insightly', []);
-
             return new Insightly($config['api_key'], $config['api_version']);
         });
-
-
-        $this->app->bind('GGDX\LaravelInsightly\Insightly', 'ggdx.insightly');
+        
     }
 
     /**


### PR DESCRIPTION
As of Laravel 5.4 share method has been removed: https://laravel.com/docs/5.4/upgrade

Recommended replacement is singleton method.

(I forgot to delete the call to bind method in the first pull request)